### PR TITLE
Fix for VSCode 1.36

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,3 @@
-
 /* Flex Tab Bar */
 
 /* Disable CVS and Split editor buttons */
@@ -11,6 +10,7 @@
   flex-direction: row;
 }
 
+/* to adjust the width of the tab-container adjust all references to 250px */
 .monaco-workbench > .part.editor > .content .editor-group-container > .title {
   overflow: visible;
   height: 100%;
@@ -37,6 +37,38 @@
   min-width: auto;
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container.empty > .editor-container  {
+/* truncate long file names and leave room for the close button */
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit .monaco-icon-label {
+  overflow: hidden;
+  width: calc(250px - 30px);
+}
+
+/* reduce the width of the editor container by the width of the tab container */
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-container  {
   width: calc(100% - 250px);
+  height: 100% !important;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-container > .editor-instance
+> .monaco-editor {
+  height: 100% !important;
+  width: 100% !important;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-container > .editor-instance
+> .monaco-editor > .overflow-guard {
+  height: 100% !important;
+  width: 100% !important;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-container > .editor-instance
+> .monaco-editor > .overflow-guard > .editor-scrollable {
+  width: calc(100% - 68px) !important;
+    height: 100% !important;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .editor-container > .editor-instance
+> .monaco-editor > .overflow-guard > .minimap {
+  transform: translateX(-250px);
+    height: 100% !important;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,41 +1,42 @@
 
 /* Flex Tab Bar */
 
-.monaco-workbench.nosidebar > .activitybar {
+/* Disable CVS and Split editor buttons */
+.editor-actions {
   display: none;
 }
 
-.monaco-workbench.nosidebar > .editor {
-left: 0 !important;
+.monaco-workbench > .part.editor > .content .editor-group-container {
+  display: flex;
+  flex-direction: row;
 }
 
-.monaco-workbench.nosidebar > .editor > .content > .one-editor-silo > .container {
-display: flex;
-flex-direction: row;
+.monaco-workbench > .part.editor > .content .editor-group-container > .title {
+  overflow: visible;
+  height: 100%;
+  width: 250px;
+  flex-direction: column;
 }
 
-.monaco-workbench.nosidebar>.part.editor>.content>.one-editor-silo>.container>.title {
-overflow: visible;
-height: 100%;
-flex-direction: column;
+.monaco-workbench .part.editor > .content .editor-group-container > .title.tabs > .tabs-and-actions-container {
+  height: 100%;
 }
 
-.monaco-workbench.nosidebar >.part.editor>.content>.one-editor-silo>.container>.title .tabs-container {
-flex-direction: column;
-height: 100%;
+.monaco-workbench .part.editor > .content .editor-group-container > .title.tabs > .tabs-and-actions-container > .monaco-scrollable-element {
+  height: 100% !important;
 }
 
-.monaco-workbench.nosidebar > .part.editor > .content > .one-editor-silo
-> .container > .title .tabs-container > .tab {
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container {
+  flex-direction: column;
+  height: 100%;
+  width: auto;
+}
+
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fit {
   width: 100%;
+  min-width: auto;
 }
 
-
-.monaco-workbench.nosidebar .monaco-editor, .monaco-editor .inputarea {
-margin-top: 17px;
-}
-
-
-.monaco-workbench.nosidebar .scroll-decoration {
-display: none !important;
+.monaco-workbench .part.editor > .content .editor-group-container.empty > .editor-container  {
+  width: calc(100% - 250px);
 }


### PR DESCRIPTION
PR #2 worked up through VSCode 1.34 but quit working in 1.35.

This css works for me in VSCode 1.36, so I thought I would share it.

You can adjust the 250px width to suit your own preference.